### PR TITLE
headerspace: Don't output through in_port

### DIFF
--- a/sts/headerspace/config_parser/openflow_parser.py
+++ b/sts/headerspace/config_parser/openflow_parser.py
@@ -309,6 +309,7 @@ def ofp_actions_to_output_ports(ofp_actions, switch, all_port_ids, in_port_id):
   def output_packet(action):
     out_port = action.port
     out_port_id = get_uniq_port_id(switch, out_port)
+    if out_port_id == in_port_id: return
     if out_port < OFPP_MAX:
       output_port_nos.append(out_port_id)
     elif out_port == OFPP_IN_PORT:


### PR DESCRIPTION
This adjusts the building of the OpenFlow transfer function so that
output actions with the out port set to the in port do not have a
result.  This is consistent with the OpenFlow specification.
